### PR TITLE
Changed old string formatting to fstrings

### DIFF
--- a/dotifi/configuration/load.py
+++ b/dotifi/configuration/load.py
@@ -7,12 +7,12 @@ from confuse import LazyConfig
 def load_configuration(args, configuration_file_path) -> LazyConfig:
     config = LazyConfig("Service", __name__)
     if configuration_file_path is not None:
-        logging.debug("configuration file path is %s", config)
+        logging.debug(f"configuration file path is {configuration_file_path}")
         if os.path.isfile(configuration_file_path):
             config_file = configuration_file_path
             config.set_file(config_file)
-            print("Loaded configuration from %s", configuration_file_path)
+            print(f"Loaded configuration from {configuration_file_path}")
         else:
-            raise Exception("%s is not a file", configuration_file_path)
+            raise Exception(f"{configuration_file_path} is not a file")
     config.set_args(args)
     return config

--- a/dotifi/dotifi.py
+++ b/dotifi/dotifi.py
@@ -212,15 +212,15 @@ def process():
     )
     # logging.root.setLevel(level)
 
-    logging.debug("Configuration:\n%s", options.dump())
+    logging.debug(f"Configuration:\n{options.dump()}")
 
     graph = None
     if options["with_existing_dot_file"].exists():
         existing_path = options["with_existing_dot_file"].as_filename()
-        logging.debug("Using existing DOT file %s", existing_path)
+        logging.debug(f"Using existing DOT file {existing_path}")
         try:
             graph = AGraph(existing_path)
-            logging.debug("Loaded graph from %s :\n%s", existing_path, graph.string())
+            logging.debug(f"Loaded graph from {existing_path} :\n{graph.string()}")
         except FileNotFoundError as e:
             logging.exception(e)
             exit(1)

--- a/dotifi/nifi/connection.py
+++ b/dotifi/nifi/connection.py
@@ -32,7 +32,7 @@ def configure_nifi_connection(configuration):
     :param configuration: confuse.LazyConfig
     """
     if logging.DEBUG >= logging.root.level:
-        logging.debug("setting nifi endpoint to %s", configuration["nifi_url"].get())
+        logging.debug(f"setting nifi endpoint to {configuration['nifi_url'].get()}")
 
     nipyapi.utils.set_endpoint(configuration["nifi_url"].get())
 
@@ -42,15 +42,15 @@ def configure_nifi_connection(configuration):
         ca_file = None
         if configuration["ca_file"].exists():
             ca_file = configuration["ca_file"].as_filename()
-            logging.debug("setting ca_file to %s", ca_file)
+            logging.debug(f"setting ca_file to {ca_file}")
         client_cert_file = None
         if configuration["client_cert_file"].exists():
             client_cert_file = configuration["client_cert_file"].as_filename()
-            logging.debug("setting client_cert_file to %s", client_cert_file)
+            logging.debug(f"setting client_cert_file to {client_cert_file}")
         client_key_file = None
         if configuration["client_key_file"].exists():
             client_key_file = configuration["client_key_file"].as_filename()
-            logging.debug("setting client_key_file to %s", client_key_file)
+            logging.debug(f"setting client_key_file to {client_key_file}")
         client_key_password = None
         if configuration["client_key_password"].exists():
             client_key_password = configuration["client_key_password"].get()
@@ -70,7 +70,7 @@ def configure_nifi_connection(configuration):
         ].get(bool):
             logging.debug("Configured for user / password authentication")
             username = configuration["nifi_username"].get()
-            logging.debug("nifi_user_name is %s", username)
+            logging.debug(f"nifi_user_name is {username}")
             password = configuration["nifi_user_password"].get()
             logging.debug("attempting to log into nifi")
             nipyapi.utils.wait_to_complete(

--- a/dotifi/nifi/generate.py
+++ b/dotifi/nifi/generate.py
@@ -48,9 +48,7 @@ def _create_port_node(subgraph, port_type, port):
     port_node.attr["label"] = port.component.name + " : " + port.component.type
     port_node.attr["pos"] = f"{port.position.x:f},{port.position.x:f}"
     port_node.attr["id"] = port.id
-    logging.debug(
-        f"Generate node for {port_type}_port {port.id}:{port.component.name}"
-    )
+    logging.debug(f"Generate node for {port_type}_port {port.id}:{port.component.name}")
 
 
 def _clone_graph_attrs(source, target):
@@ -108,9 +106,7 @@ def _handle_group(
             template_file = configuration["process_groups"][process_group.id][
                 "template"
             ].as_filename()
-            logging.debug(
-                f"Using template file {template_file} for {process_group.id}"
-            )
+            logging.debug(f"Using template file {template_file} for {process_group.id}")
             template_group_graph = pgv.AGraph(template_file)
             # process_group_graph = parent_graph.add_subgraph(process_group_graph)
             process_group_graph = parent_graph.add_subgraph(
@@ -125,7 +121,7 @@ def _handle_group(
             process_group_graph.graph_attr["label"] = process_group.component.name
             process_group_graph.graph_attr["id"] = process_group.id
             logging.debug(
-                f"Created subgraph {process_group_graph.name} " \
+                f"Created subgraph {process_group_graph.name} "
                 f"with label {process_group.component.name}"
             )
 
@@ -165,7 +161,7 @@ def _handle_group(
         node.attr["pos"] = f"{processor.position.x:f},{processor.position.y:f}"
         node.attr["id"] = processor.id
         logging.debug(
-            f"Generate node for processor {processor.id}:{processor.component.name}" 
+            f"Generate node for processor {processor.id}:{processor.component.name}"
         )
 
         # see if user has configured a set of attributes for this processor
@@ -192,7 +188,7 @@ def _handle_group(
         remote_subgraph.graph_attr["id"] = remote_group.id
 
         logging.debug(
-            "Generate node for Remote Process Group " \
+            "Generate node for Remote Process Group "
             f"{remote_group.component.name}:{remote_group.component.target_uri}"
         )
 
@@ -222,12 +218,12 @@ def _handle_group(
                     "remote_process_groups"
                 ][remote_group.id]["node_attr"][key].get()
                 logging.debug(
-                    f"Set Remote Process Group {remote_group.component.name} " \
+                    f"Set Remote Process Group {remote_group.component.name} "
                     f"configured graph attribute {key} to {remote_subgraph.graph_attr[key]}"
                 )
         for input_port in remote_process_group["input_ports"]:
             logging.debug(
-                f"Found Remote Process Group {remote_group.component.name} "\
+                f"Found Remote Process Group {remote_group.component.name} "
                 f"input port {input_port.id}"
             )
             remote_subgraph.add_node(input_port.id)
@@ -237,7 +233,7 @@ def _handle_group(
             )
             remote_input_port_node.attr["id"] = input_port.id
             logging.debug(
-                f"Generated node for Remote Process Group {remote_group.component.name} " \
+                f"Generated node for Remote Process Group {remote_group.component.name} "
                 f"input port {input_port.id}"
             )
     logging.debug(f"Checking connections for {process_group.id} flow")
@@ -389,8 +385,7 @@ def generate_graph(generate_configuration) -> pgv.AGraph:
             _set_default_root_attrs(_root_graph)
 
         if logging.DEBUG >= logging.root.level:
-            logging.debug("ROOT GRAPH : \n" \
-            f"{_root_graph.string()}")
+            logging.debug("ROOT GRAPH : \n" f"{_root_graph.string()}")
         root_id = nipyapi.canvas.get_root_pg_id()
         _add_mock_info(do_mock, mock, "nipyapi.canvas.get_root_pg_id", data=root_id)
         root_group = nipyapi.canvas.get_process_group(root_id, identifier_type="id")

--- a/dotifi/nifi/generate.py
+++ b/dotifi/nifi/generate.py
@@ -49,7 +49,7 @@ def _create_port_node(subgraph, port_type, port):
     port_node.attr["pos"] = f"{port.position.x:f},{port.position.x:f}"
     port_node.attr["id"] = port.id
     logging.debug(
-        "Generate node for %s_port %s:%s", port_type, port.id, port.component.name
+        f"Generate node for {port_type}_port {port.id}:{port.component.name}"
     )
 
 
@@ -90,7 +90,7 @@ def _handle_group(
     :param mock_info: mock data storage
     :return:
     """
-    logging.debug("Handling group %s", process_group.id)
+    logging.debug(f"Handling group {process_group.id}")
     this_flow = nipyapi.canvas.get_flow(process_group.id)
     _add_mock_info(
         do_mock,
@@ -109,7 +109,7 @@ def _handle_group(
                 "template"
             ].as_filename()
             logging.debug(
-                "Using template file %s for %d", template_file, process_group.id
+                f"Using template file {template_file} for {process_group.id}"
             )
             template_group_graph = pgv.AGraph(template_file)
             # process_group_graph = parent_graph.add_subgraph(process_group_graph)
@@ -125,9 +125,8 @@ def _handle_group(
             process_group_graph.graph_attr["label"] = process_group.component.name
             process_group_graph.graph_attr["id"] = process_group.id
             logging.debug(
-                "Created subgraph %s with label %s",
-                process_group_graph.name,
-                process_group.component.name,
+                f"Created subgraph {process_group_graph.name} " \
+                f"with label {process_group.component.name}"
             )
 
     input_ports = nipyapi.canvas.list_all_input_ports(process_group.id, False)
@@ -166,21 +165,18 @@ def _handle_group(
         node.attr["pos"] = f"{processor.position.x:f},{processor.position.y:f}"
         node.attr["id"] = processor.id
         logging.debug(
-            "Generate node for processor %s:%s", processor.id, processor.component.name
+            f"Generate node for processor {processor.id}:{processor.component.name}" 
         )
 
         # see if user has configured a set of attributes for this processor
         if configuration["processors"][processor.id]["node_attr"].exists():
-            logging.debug("Processor %s has configured attributes", processor.id)
+            logging.debug(f"Processor {processor.id} has configured attributes")
             for key in configuration["processors"][processor.id]["node_attr"]:
                 node.attr[key] = configuration["processors"][processor.id]["node_attr"][
                     key
                 ].get()
                 logging.debug(
-                    "Set Processor %s configured attribute %s to %s",
-                    processor.id,
-                    key,
-                    node.attr[key],
+                    f"Set Processor {processor.id} configured attribute {key} to {node.attr[key]}"
                 )
 
     for remote_group in this_flow.process_group_flow.flow.remote_process_groups:
@@ -196,9 +192,8 @@ def _handle_group(
         remote_subgraph.graph_attr["id"] = remote_group.id
 
         logging.debug(
-            "Generate node for Remote Process Group %s:%s",
-            remote_group.component.name,
-            remote_group.component.target_uri,
+            "Generate node for Remote Process Group " \
+            f"{remote_group.component.name}:{remote_group.component.target_uri}"
         )
 
         remote_process_group = nipyapi.canvas.get_remote_process_group(
@@ -218,8 +213,7 @@ def _handle_group(
             "node_attr"
         ].exists():
             logging.debug(
-                "Remote Process Group %s has configured attributes",
-                remote_group.component.name,
+                f"Remote Process Group {remote_group.component.name} has configured attributes"
             )
             for key in configuration["remote_process_groups"][remote_group.id][
                 "node_attr"
@@ -228,16 +222,13 @@ def _handle_group(
                     "remote_process_groups"
                 ][remote_group.id]["node_attr"][key].get()
                 logging.debug(
-                    "Set Remote Process Group %s configured graph attribute %s to %s",
-                    remote_group.component.name,
-                    key,
-                    remote_subgraph.graph_attr[key],
+                    f"Set Remote Process Group {remote_group.component.name} " \
+                    f"configured graph attribute {key} to {remote_subgraph.graph_attr[key]}"
                 )
         for input_port in remote_process_group["input_ports"]:
             logging.debug(
-                "Found Remote Process Group %s input port %s",
-                remote_group.component.name,
-                input_port.id,
+                f"Found Remote Process Group {remote_group.component.name} "\
+                f"input port {input_port.id}"
             )
             remote_subgraph.add_node(input_port.id)
             remote_input_port_node = remote_subgraph.get_node(input_port.id)
@@ -246,11 +237,10 @@ def _handle_group(
             )
             remote_input_port_node.attr["id"] = input_port.id
             logging.debug(
-                "Generated node for Remote Process Group %s input port %s",
-                remote_group.component.name,
-                input_port.id,
+                f"Generated node for Remote Process Group {remote_group.component.name} " \
+                f"input port {input_port.id}"
             )
-    logging.debug("Checking connections for %s flow", process_group.id)
+    logging.debug(f"Checking connections for {process_group.id} flow")
     for connection in this_flow.process_group_flow.flow.connections:
         if connection.component.selected_relationships is not None:
             for relationship in connection.component.selected_relationships:
@@ -270,16 +260,14 @@ def _handle_group(
             )
             edge.attr["label"] = connection.component.name
         logging.debug(
-            "Generated Edge from %s to %s",
-            connection.source_id,
-            connection.destination_id,
+            f"Generated Edge from {connection.source_id} to {connection.destination_id}"
         )
 
     # check and see if we are at the configured depth or that we can keep going
     configured_depth = int(configuration["depth"].get())
     next_depth = current_depth + 1
     if (configured_depth == -1) or (next_depth <= configured_depth):
-        logging.debug("Moving to depth %d", next_depth)
+        logging.debug(f"Moving to depth {next_depth}")
         process_groups_api = nipyapi.nifi.ProcessGroupsApi()
         _add_mock_info(
             do_mock, mock_info, "nipyapi.nifi.ProcessGroupsApi", data=process_groups_api
@@ -309,9 +297,7 @@ def _handle_group(
             )
     else:
         logging.debug(
-            "Max depth %d met in Process Group %s, stopping",
-            configured_depth,
-            process_group.id,
+            f"Max depth {configured_depth} met in Process Group {process_group.id}, stopping"
         )
 
 
@@ -355,7 +341,7 @@ def generate_graph(generate_configuration) -> pgv.AGraph:
     # check if the user wishes to start somewhere other than the root
     if generate_configuration["start_at_pg"].exists():
         root_id = generate_configuration["start_at_pg"].get()
-        logging.debug("using specified start_at_pg %s", root_id)
+        logging.debug(f"using specified start_at_pg {root_id}")
         root_group = nipyapi.canvas.get_process_group(root_id, identifier_type="id")
         _add_mock_info(
             do_mock,
@@ -371,9 +357,7 @@ def generate_graph(generate_configuration) -> pgv.AGraph:
                 root_id
             ].as_filename()
             logging.debug(
-                "specified start_at_pg %s has a configured template %s",
-                root_id,
-                template_file,
+                f"specified start_at_pg {root_id} has a configured template {template_file}"
             )
             _root_graph = pgv.AGraph(template_file)
             logging.debug("root graph based on start_at_pg.id and template created")
@@ -397,7 +381,7 @@ def generate_graph(generate_configuration) -> pgv.AGraph:
             graph_template_file = generate_configuration["graph"][
                 "template"
             ].as_filename()
-            logging.debug("Graph has a configured template %s", graph_template_file)
+            logging.debug(f"Graph has a configured template {graph_template_file}")
             _root_graph = pgv.AGraph(graph_template_file)
         else:
             logging.debug("root graph will be created from defaults")
@@ -405,7 +389,8 @@ def generate_graph(generate_configuration) -> pgv.AGraph:
             _set_default_root_attrs(_root_graph)
 
         if logging.DEBUG >= logging.root.level:
-            logging.debug("ROOT GRAPH : \n%s", _root_graph.string())
+            logging.debug("ROOT GRAPH : \n" \
+            f"{_root_graph.string()}")
         root_id = nipyapi.canvas.get_root_pg_id()
         _add_mock_info(do_mock, mock, "nipyapi.canvas.get_root_pg_id", data=root_id)
         root_group = nipyapi.canvas.get_process_group(root_id, identifier_type="id")

--- a/dotifi/publishing/publish.py
+++ b/dotifi/publishing/publish.py
@@ -10,7 +10,7 @@ def publish(publish_configuration, graph):
     """
 
     dot_name = publish_configuration["output_dot_file"].as_filename()
-    logging.debug("Graph will be written as dot file: %s", dot_name)
+    logging.debug(f"Graph will be written as dot file: {dot_name}")
     graphic_file_name = publish_configuration["output_graphviz_file"].as_filename()
     graphic_program = publish_configuration["output_graphviz_program"].get()
     graphviz_fmt = publish_configuration["output_graphviz_format"].as_choice(
@@ -60,8 +60,8 @@ def publish(publish_configuration, graph):
         dot_name = dot_name + ".gv"
 
     graph.write(dot_name)
-    logging.debug("Wrote %s", dot_name)
+    logging.debug(f"Wrote {dot_name}")
     graph.draw(graphic_file_name, prog=graphic_program, format=graphviz_fmt)
     logging.debug(
-        "Wrote %s prog= %s  format=%s", graphic_file_name, graphic_program, graphviz_fmt
+        f"Wrote {graphic_file_name} prog= {graphic_program}  format={graphviz_fmt}"
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -70,12 +70,12 @@ def _start_docker_containers(docker_containers, network_name="test"):
     # Pull relevant Images
     log.info("Pulling relevant Docker Images if needed")
     for image in set([(c.image_name + ":" + c.image_tag) for c in docker_containers]):
-        log.info("Checking image %s", image)
+        log.info(f"Checking image {image}")
         try:
             d_client.images.get(image)
-            log.info("Using local image for %s", image)
+            log.info(f"Using local image for {image}")
         except ImageNotFound:
-            log.info("Pulling %s", image)
+            log.info(f"Pulling {image}")
             d_client.images.pull(image)
 
     # Clear previous containers
@@ -86,7 +86,7 @@ def _start_docker_containers(docker_containers, network_name="test"):
         if li.name in [i.name for i in docker_containers]
     ]
     for c in d_clear_list:
-        log.info("Removing old container %s", c.name)
+        log.info(f"Removing old container {c.name}")
         c.remove(force=True)
 
     # Deploy/Get Network
@@ -100,12 +100,12 @@ def _start_docker_containers(docker_containers, network_name="test"):
         raise EnvironmentError("Too many test networks found")
     else:
         d_network = d_n_list[0]
-    log.info("Using Docker network: %s", d_network.name)
+    log.info(f"Using Docker network: {d_network.name}")
 
     # Deploy Containers
     log.info("Starting relevant Docker Containers")
     for c in docker_containers:
-        log.info("Starting Container %s", c.name)
+        log.info(f"Starting Container {c.name}")
         c.set_container(
             d_client.containers.run(
                 image=c.image_name + ":" + c.image_tag,


### PR DESCRIPTION
Fixes #72 

@ottobackwards  Changed all old string formatting used in print and logging statements to new fstrings style.

Note:
Changed a variable name in one of the logging statement in https://github.com/palindromicity/dotifi/blob/main/dotifi/configuration/load.py#L10 from `config` (which is a object) to `configuration_file_path` which looked appropriate. Please review.

```
❯ poetry run pytest -v
============================================================================================================ test session starts =============================================================================================================
platform darwin -- Python 3.8.5, pytest-4.6.11, py-1.9.0, pluggy-0.13.1 -- /Users/balaji/anaconda3/envs/dotifi/bin/python
cachedir: .pytest_cache
rootdir: /Users/balaji/ws/git_works/dotifi
plugins: mock-3.2.0
collected 10 items

tests/test_dotifi.py::test_version PASSED                                                                                                                                                                                              [ 10%]
tests/integration/test_secure.py::test_happy_path SKIPPED                                                                                                                                                                              [ 20%]
tests/unit_tests/configuration/test_dotifi_util_configuration.py::test_load_sample_configuration PASSED                                                                                                                                [ 30%]
tests/unit_tests/configuration/test_dotifi_util_configuration.py::test_load_env_configuration PASSED                                                                                                                                   [ 40%]
tests/unit_tests/nifi/test_mock_generate.py::test_happy_path[path_arg0] PASSED                                                                                                                                                         [ 50%]
tests/unit_tests/nifi/test_mock_generate.py::test_start_pg[path_arg0] PASSED                                                                                                                                                           [ 60%]
tests/unit_tests/nifi/test_mock_generate.py::test_rpg_attribute_override[path_arg0] PASSED                                                                                                                                             [ 70%]
tests/unit_tests/nifi/test_mock_generate.py::test_processor_attribute_override[path_arg0] PASSED                                                                                                                                       [ 80%]
tests/unit_tests/nifi/test_mock_generate.py::test_graph_template[path_arg0] PASSED                                                                                                                                                     [ 90%]
tests/unit_tests/nifi/test_mock_generate.py::test_pg_template[path_arg0] PASSED                                                                                                                                                        [100%]

==================================================================================================== 9 passed, 1 skipped in 0.83 seconds =====================================================================================================
```